### PR TITLE
Make version number work well with build tools

### DIFF
--- a/funiculi/cli.py
+++ b/funiculi/cli.py
@@ -1,5 +1,6 @@
 """Entry point for the command line interface."""
 
+import os
 import sys
 from typing import NoReturn
 
@@ -8,9 +9,19 @@ import fire  # type: ignore
 from . import __version__, api, fire_workarounds
 from .errors import CliError
 from .logging import get_logger
+from .settings import PROJECT_ROOT, PYPROJECT_TOML
 
 
 logger = get_logger(__name__)
+
+
+def _version_text() -> str:
+    if __version__ is None:
+        return 'Funiculi (unknown version)'
+    if os.path.exists(PYPROJECT_TOML):
+        return f'Funiculi v{__version__}' \
+            + f' (in development at {PROJECT_ROOT})'
+    return f'Funiculi v{__version__}'
 
 
 def run(*args: str) -> NoReturn:
@@ -18,10 +29,7 @@ def run(*args: str) -> NoReturn:
     """Runs the command line interface."""
 
     if sys.argv[1:] and sys.argv[1:][0] in {'-V', '--version'}:
-        if __version__ is None:
-            print('Funiculi (unknown version)')
-        else:
-            print(f'Funiculi v{__version__}')
+        print(_version_text())
         sys.exit(0)
 
     fire_workarounds.apply()

--- a/funiculi/settings.py
+++ b/funiculi/settings.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).parent.parent.absolute()
 PACKAGE_ROOT = Path(__file__).parent.absolute()
+PYPROJECT_TOML = PROJECT_ROOT / 'pyproject.toml'
 
 DEFAULT_AVR_CTRL_PORT = 23
 DEFAULT_AVR_WEB_PORT = 60006

--- a/funiculi/version.py
+++ b/funiculi/version.py
@@ -4,7 +4,7 @@ from contextlib import suppress
 import importlib.metadata
 from typing import Union
 
-from .settings import PROJECT_ROOT
+from .settings import PYPROJECT_TOML
 
 
 def version() -> Union[str, None]:
@@ -16,21 +16,17 @@ def version() -> Union[str, None]:
 
     :return:
         a version string if one is found, None otherwise.
-
-        The version string may be trailed by an explanation such as
-        ` (in development at path/to/project)` if the package is
-        invoked from a development tree.
     """
     with suppress(FileNotFoundError, StopIteration):
-        with open(
-            PROJECT_ROOT / 'pyproject.toml', encoding='utf-8',
-        ) as pyproject_toml:
+        with open(PYPROJECT_TOML, encoding='utf-8') as pyproject_toml:
             # Parse manually due to Debian 11 missing a `tomli` package
             version_lines = (
                 line for line in pyproject_toml
                 if line.startswith('version '))
-            return next(version_lines).split('=')[1].strip("'\"\n ") \
-                + f' (in development at {PROJECT_ROOT})'
+            return next(version_lines).split('=')[1].strip("'\"\n ")
+
+    with suppress(FileNotFoundError):
         return importlib.metadata.version(
             __package__ or __name__.split('.', maxsplit=1)[0])
+
     return None


### PR DESCRIPTION
In 3d15088, a `__version__` variable was introduced with a conditional
suffix, e.g. ` (in development at /path/to/projectroot)'`.

Turns out that `__version__` may be consumed by build tools, too.
Inserting such a suffix may break the build in the best case (because it
detects the PEP 440 violation, like pybuild does) or it may silently
leak the suffix into production in the worst case.

Move the suffix out of `__version__` into the `--version` handler, which
now checks the presence of `pyproject.toml` separately and then appends
the suffix if need be.
