### PR TITLE
README: use definition lists for compatibility

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -10,24 +10,24 @@ funiculi [FLAGS] COMMAND
 
 `COMMAND` is one of the following:
 
-- `off`  
-  Turns the device off.
+`off`
+: Turns the device off.
 
-- `on`  
-  Turns the device on.
+`on`
+: Turns the device on.
 
-- `down`  
-  Turns the volume down one step.
+`down`
+: Turns the volume down one step.
 
-- `up`  
-  Turns the volume up one step.
+`up`
+: Turns the volume up one step.
 
-- `status`  
-  Queries whether the device is on standby.
+`status`
+: Queries whether the device is on standby.
 
-- `dlna`  
-  Sets up a local virtual output device that relays all audio to the
-  receiver via DLNA.
+`dlna`
+: Sets up a local virtual output device that relays all audio to the
+: receiver via DLNA.
 
 # Flags
 

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -19,6 +19,10 @@ extensions = [
     'sphinx.ext.napoleon',
 ]
 
+myst_enable_extensions = [
+    'deflist',
+]
+
 templates_path = []
 exclude_patterns = []
 


### PR DESCRIPTION
Using definition lists has the following benefits:

1. less workarounds in the source;

2. less reliance on hard line breaks;

3. less cluttered end result (because it makes the man page lose the
   superfluous bullets); and

4. better compatibility with the Pandoc-based fallback process.
   (In Byzantium, which doesn’t provide myst-parser, we use Pandoc
   directly as a fallback mechanism. But Pandoc interprets the former
   hard-line-breaks-in-bullets workaround differently, which led to
   an unsightly additional line breakfollowing each bullet character.)
